### PR TITLE
Add waiting queue length limit with 503 error

### DIFF
--- a/tests/v1/scheduler/test_max_waiting_queue_length.py
+++ b/tests/v1/scheduler/test_max_waiting_queue_length.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.engine.arg_utils import EngineArgs
+from vllm.sampling_params import SamplingParams
+from vllm.v1.engine.exceptions import SchedulerWaitingQueueFullError
+from vllm.v1.engine.llm_engine import LLMEngine as V1LLMEngine
+
+
+def test_waiting_queue_full(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+        m.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+        engine_args = EngineArgs(
+            model="facebook/opt-125m",
+            enforce_eager=True,
+            max_waiting_queue_length=1,
+        )
+        engine = V1LLMEngine.from_engine_args(engine_args=engine_args)
+
+        sampling_params = SamplingParams(max_tokens=1)
+        engine.add_request("0", "foo", sampling_params)
+
+        with pytest.raises(SchedulerWaitingQueueFullError):
+            engine.add_request("1", "bar", sampling_params)
+
+        engine.shutdown()

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2053,6 +2053,11 @@ class SchedulerConfig:
     """Apply a delay (of delay factor multiplied by previous
     prompt latency) before scheduling next prompt."""
 
+    max_waiting_queue_length: Optional[int] = None
+    """Maximum number of requests allowed in the scheduler waiting queue.
+
+    ``None`` means the waiting queue is unbounded."""
+
     enable_chunked_prefill: SkipValidation[bool] = None  # type: ignore
     """If True, prefill requests can be chunked based
     on the remaining max_num_batched_tokens."""
@@ -2271,6 +2276,11 @@ class SchedulerConfig:
                 f"max_long_partial_prefills ({self.max_long_partial_prefills}) "
                 "must be greater than or equal to 1 and less than or equal to "
                 f"max_num_partial_prefills ({self.max_num_partial_prefills}).")
+
+        if (self.max_waiting_queue_length is not None
+                and self.max_waiting_queue_length <= 0):
+            raise ValueError(
+                "max_waiting_queue_length must be greater than 0 if set.")
 
     @property
     def is_multi_step(self) -> bool:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -326,6 +326,8 @@ class EngineArgs:
     long_prefill_token_threshold: int = \
         SchedulerConfig.long_prefill_token_threshold
     max_num_seqs: Optional[int] = SchedulerConfig.max_num_seqs
+    max_waiting_queue_length: Optional[int] = (
+        SchedulerConfig.max_waiting_queue_length)
     max_logprobs: int = ModelConfig.max_logprobs
     disable_log_stats: bool = False
     revision: Optional[str] = ModelConfig.revision
@@ -824,6 +826,9 @@ class EngineArgs:
         scheduler_group.add_argument("--max-num-seqs",
                                      **scheduler_kwargs["max_num_seqs"])
         scheduler_group.add_argument(
+            "--max-waiting-queue-length",
+            **scheduler_kwargs["max_waiting_queue_length"])
+        scheduler_group.add_argument(
             "--max-num-partial-prefills",
             **scheduler_kwargs["max_num_partial_prefills"])
         scheduler_group.add_argument(
@@ -1184,6 +1189,7 @@ class EngineArgs:
             max_num_partial_prefills=self.max_num_partial_prefills,
             max_long_partial_prefills=self.max_long_partial_prefills,
             long_prefill_token_threshold=self.long_prefill_token_threshold,
+            max_waiting_queue_length=self.max_waiting_queue_length,
             disable_hybrid_kv_cache_manager=self.
             disable_hybrid_kv_cache_manager,
         )

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -18,6 +18,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from starlette.datastructures import Headers
 from typing_extensions import TypeIs
 
+from vllm.v1.engine.exceptions import SchedulerWaitingQueueFullError
+
 if sys.version_info >= (3, 12):
     from typing import TypedDict
 else:
@@ -392,6 +394,12 @@ class OpenAIServing:
 
             return None
 
+        except SchedulerWaitingQueueFullError as e:
+            return self.create_error_response(
+                str(e),
+                err_type="ServiceUnavailableError",
+                status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            )
         except Exception as e:
             return self.create_error_response(str(e))
 

--- a/vllm/v1/engine/exceptions.py
+++ b/vllm/v1/engine/exceptions.py
@@ -15,3 +15,8 @@ class EngineDeadError(Exception):
         # Make stack trace clearer when using with LLMEngine by
         # silencing irrelevant ZMQError.
         self.__suppress_context__ = suppress_context
+
+
+class SchedulerWaitingQueueFullError(Exception):
+    """Raised when the scheduler waiting queue is full."""
+    pass


### PR DESCRIPTION
## Summary
- limit scheduler waiting queue via `max_waiting_queue_length`
- propagate new `SchedulerWaitingQueueFullError` and return HTTP 503
- expose CLI arg `--max-waiting-queue-length`
- add regression test for queue overflow

## Testing
- `pre-commit run --files vllm/config.py vllm/engine/arg_utils.py vllm/v1/core/sched/scheduler.py vllm/v1/engine/exceptions.py vllm/entrypoints/openai/serving_engine.py vllm/entrypoints/openai/serving_completion.py vllm/entrypoints/openai/serving_transcription.py vllm/entrypoints/launcher.py tests/v1/scheduler/test_max_waiting_queue_length.py`
- `pytest tests/v1/scheduler/test_max_waiting_queue_length.py -q` *(fails: ModuleNotFoundError: No module named 'msgspec')*

------
https://chatgpt.com/codex/tasks/task_e_685c0b3cd91483239766cf051a89d6d2